### PR TITLE
Restructure to make more upstreamable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ASAP7PDK"
 uuid = "5f726cbb-fb92-4cd0-9fae-dbb64c46e42b"
-authors = ["Pepijn de Vos <pepijn.devos@juliahub.com>"]
 version = "0.1.1"
+path = "cedar/ASAP7PDK.jl"
 
 [deps]
 CMC = "db13d295-e716-48aa-bdca-f6cce3d4ecc6"

--- a/cedar/ASAP7PDK.jl
+++ b/cedar/ASAP7PDK.jl
@@ -4,7 +4,7 @@ module asap7_tt
     using CedarSim
     using CMC: bsimcmg107
     sp"""
-    .include "../models/hspice/7nm_TT.pm"
+    .include "../models/hspice/7nm_TT_160803.pm"
     """
 end
 
@@ -12,7 +12,7 @@ module asap7_ff
     using CedarSim
     using CMC: bsimcmg107
     sp"""
-    .include "../models/hspice/7nm_FF.pm"
+    .include "../models/hspice/7nm_FF_160803.pm"
     """
 end
 
@@ -20,7 +20,7 @@ module asap7_ss
     using CedarSim
     using CMC: bsimcmg107
     sp"""
-    .include "../models/hspice/7nm_SS.pm"
+    .include "../models/hspice/7nm_SS_160803.pm"
     """
 end
 


### PR DESCRIPTION
I'd potentially like to use this PDK as a guinea pig for upstreaming the Cedar support to an official pdk package. As discussed, it seems unlikely that we can do that for openpdks for the forseeable future, since that's managed as a git-repo + pile-of-patches. However, OpenROAD manages ASAP7 as a github repo (even though they are not the authors), so it seems possible we could upstream it there. I don't think we're quite ready for that conversation yet, but to that end, at lest:

- Move the julia files into a `cedar` subdirectory
- Use the actual files rather than their symlinks for windows compat
- rm `authors` field from the Project.toml, since the Project.toml applies to the whole package in principle and we didn't write the PDK

I'd also, ideally like to get rid of the `CMC` dependency (cedar should load that internally when it sees as appropriate level), but that's fine for now.

Needs to wait until we pull https://github.com/JuliaLang/Pkg.jl/pull/3850 into blessed, since this will not be installable otherwise.